### PR TITLE
Update .gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,5 +1,5 @@
 [alias]
-    br = branch
+    br = branch -vv
     co = checkout
     cob = checkout -b
     delete-merged-branches = "!git co master && git branch --merged | grep -v '\\*' | xargs -n 1 git branch -d"


### PR DESCRIPTION
Add `-vv` switch to `git br`. From `git help branch`:
```
-v, -vv, --verbose
    When in list mode, show sha1 and commit subject line for each head, along with relationship to upstream branch (if any). If given twice, print the name of the upstream branch, as well
    (see also git remote show <remote>).
```